### PR TITLE
Convert domain_validation_options to a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,12 +32,12 @@ resource "aws_acm_certificate" "wildcard" {
 
 resource "aws_route53_record" "cert_validation" {
   zone_id = data.aws_route53_zone.main.id
-  name    = aws_acm_certificate.main.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.main.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.main.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.main.domain_validation_options)[0].resource_record_type
   ttl     = 60
 
   records = [
-    aws_acm_certificate.main.domain_validation_options[0].resource_record_value,
+    tolist(aws_acm_certificate.main.domain_validation_options)[0].resource_record_value,
   ]
 }
 


### PR DESCRIPTION

# Pull Request

## Description
The AWS provider has been updated to v3.0, where domain_validation_options is now a set (previously a list). The current version of the module will thus fail if you use the new AWS provider.

The changes introduced here align with the [official upgrade guide for AWS provider v3.0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_acm_certificate), and should be backwards-compatible. Provider versions < 3.0 will simply convert a list to a list.

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran `terraform apply` using both AWS provider 2.70 and 3.0.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/` directories (look in CI for an example)
- [ ] Provide an updated example that utilizes newly created resources, or for more advanced additions a new example under the examples directory.
- [ ] Example plan output in this PR (in lieu of CI)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] Any breaking changes are noted in the description above
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project
- [ ] Any dependent changes have been merged and published in downstream modules